### PR TITLE
Load all access types

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,7 +58,7 @@ const access_types =  createListCollection({
   items: [
     {label:"Public Transit (Peak)", value:"acs_public_transit_peak"},
     {label:"Public Transit (Off Peak)", value:"acs_public_transit_offpeak"},
-    {label:"Cycling", value:"acs_cycling"},
+    {label:"Cycling", value:"acs_cycling"}, //acs_idx_hf_acs_cycling
     {label:"Walking", value:"acs_walking"},
   ],
 });
@@ -80,8 +80,8 @@ function App() {
 
 
   const { arrow: data, loading } = useDuckDbQuery(`
-    SELECT st_aswkb(geometry) as geometry, acs_idx_emp, acs_idx_hf, acs_idx_ef, acs_idx_psef, acs_idx_srf, acs_idx_caf
-    FROM access_measures.parquet WHERE type='${access_class}' AND CSDNAME='${city}';
+    SELECT st_aswkb(geometry) as geometry, *
+    FROM access_measures.parquet WHERE CSDNAME='${city}';
   `);
 
   const table = useMemo(() => {
@@ -105,12 +105,41 @@ function App() {
 
     const dataTable = new Table({
       geometry: makeVector(polygonData),
-      acs_idx_emp: makeVector(data.getChild("acs_idx_emp")?.toArray()),
-      acs_idx_hf: makeVector(data.getChild("acs_idx_hf")?.toArray()),
-      acs_idx_ef: makeVector(data.getChild("acs_idx_ef")?.toArray()),
-      acs_idx_psef: makeVector(data.getChild("acs_idx_psef")?.toArray()),
-      acs_idx_srf: makeVector(data.getChild("acs_idx_srf")?.toArray()),
-      acs_idx_caf: makeVector(data.getChild("acs_idx_caf")?.toArray())
+      // Healthcare Facilities combinations
+      acs_idx_hf_acs_cycling: makeVector(data.getChild("acs_idx_hf_acs_cycling")?.toArray()),
+      acs_idx_hf_acs_public_transit_offpeak: makeVector(data.getChild("acs_idx_hf_acs_public_transit_offpeak")?.toArray()),
+      acs_idx_hf_acs_public_transit_peak: makeVector(data.getChild("acs_idx_hf_acs_public_transit_peak")?.toArray()),
+      acs_idx_hf_acs_walking: makeVector(data.getChild("acs_idx_hf_acs_walking")?.toArray()),
+      
+      // Employment combinations
+      acs_idx_emp_acs_cycling: makeVector(data.getChild("acs_idx_emp_acs_cycling")?.toArray()),
+      acs_idx_emp_acs_public_transit_offpeak: makeVector(data.getChild("acs_idx_emp_acs_public_transit_offpeak")?.toArray()),
+      acs_idx_emp_acs_public_transit_peak: makeVector(data.getChild("acs_idx_emp_acs_public_transit_peak")?.toArray()),
+      acs_idx_emp_acs_walking: makeVector(data.getChild("acs_idx_emp_acs_walking")?.toArray()),
+      
+      // Sport and Recreation Facilities combinations
+      acs_idx_srf_acs_cycling: makeVector(data.getChild("acs_idx_srf_acs_cycling")?.toArray()),
+      acs_idx_srf_acs_public_transit_offpeak: makeVector(data.getChild("acs_idx_srf_acs_public_transit_offpeak")?.toArray()),
+      acs_idx_srf_acs_public_transit_peak: makeVector(data.getChild("acs_idx_srf_acs_public_transit_peak")?.toArray()),
+      acs_idx_srf_acs_walking: makeVector(data.getChild("acs_idx_srf_acs_walking")?.toArray()),
+      
+      // Post-secondary Education combinations
+      acs_idx_psef_acs_cycling: makeVector(data.getChild("acs_idx_psef_acs_cycling")?.toArray()),
+      acs_idx_psef_acs_public_transit_offpeak: makeVector(data.getChild("acs_idx_psef_acs_public_transit_offpeak")?.toArray()),
+      acs_idx_psef_acs_public_transit_peak: makeVector(data.getChild("acs_idx_psef_acs_public_transit_peak")?.toArray()),
+      acs_idx_psef_acs_walking: makeVector(data.getChild("acs_idx_psef_acs_walking")?.toArray()),
+      
+      // Primary and Secondary Education combinations
+      acs_idx_ef_acs_cycling: makeVector(data.getChild("acs_idx_ef_acs_cycling")?.toArray()),
+      acs_idx_ef_acs_public_transit_offpeak: makeVector(data.getChild("acs_idx_ef_acs_public_transit_offpeak")?.toArray()),
+      acs_idx_ef_acs_public_transit_peak: makeVector(data.getChild("acs_idx_ef_acs_public_transit_peak")?.toArray()),
+      acs_idx_ef_acs_walking: makeVector(data.getChild("acs_idx_ef_acs_walking")?.toArray()),
+      
+      // Cultural and Arts Facilities combinations
+      acs_idx_caf_acs_cycling: makeVector(data.getChild("acs_idx_caf_acs_cycling")?.toArray()),
+      acs_idx_caf_acs_public_transit_offpeak: makeVector(data.getChild("acs_idx_caf_acs_public_transit_offpeak")?.toArray()),
+      acs_idx_caf_acs_public_transit_peak: makeVector(data.getChild("acs_idx_caf_acs_public_transit_peak")?.toArray()),
+      acs_idx_caf_acs_walking: makeVector(data.getChild("acs_idx_caf_acs_walking")?.toArray())
     });
 
     dataTable.schema.fields[0].metadata.set(
@@ -154,6 +183,7 @@ function App() {
           data={table?.table}
           bbox={table?.bbox}
           access={access}
+          access_class={access_class}
         />
       )}
       <Box bg="white" w="20rem" p="7" position="absolute" top="4" left="4" boxShadow="md" zIndex={1000}>

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -13,6 +13,7 @@ interface Props {
   data?: Table;
   bbox?: [number, number, number, number];
   access: string;
+  access_class: string;
 }
 
 function DeckGLOverlay(props: DeckProps) {
@@ -21,12 +22,13 @@ function DeckGLOverlay(props: DeckProps) {
   return null;
 }
 
-export default function Map({ data, bbox, access }: Props) {
+export default function Map({ data, bbox, access, access_class }: Props) {
   const mapRef = useRef<MapRef>(null);
 
-  const { getColor} = useColorScale(data, access);
+  const { getColor} = useColorScale(data, access, access_class);
 
   const layers = useMemo(() => {
+    const columnName = [access, access_class].join("_");
     return [
       data && new GeoArrowPolygonLayer({
         id: `geoarrow-polygons`,
@@ -36,7 +38,7 @@ export default function Map({ data, bbox, access }: Props) {
         getFillColor: ({ index, data, target }) => {
           const recordBatch = data.data;
           const row = recordBatch.get(index);
-          const value = row ? row[access]: 0;
+          const value = row ? row[columnName]: 0;
           const [r, g, b] = getColor(value);
           target[0] = r;
           target[1] = g;
@@ -46,11 +48,11 @@ export default function Map({ data, bbox, access }: Props) {
         },
         lineWidthMinPixels: 0,
         updateTriggers: {
-          getFillColor: access
+          getFillColor: columnName
         }
       }),
     ];
-  }, [data, getColor, access]);
+  }, [data, access, access_class]);
 
   useEffect(() => {
     if (!mapRef.current || !bbox) return;

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -29,7 +29,7 @@ export default function Map({ data, bbox, access }: Props) {
   const layers = useMemo(() => {
     return [
       data && new GeoArrowPolygonLayer({
-        id: `geoarrow-polygons-${access}`,
+        id: `geoarrow-polygons`,
         stroked: false,
         filled: true,
         data,
@@ -45,6 +45,9 @@ export default function Map({ data, bbox, access }: Props) {
           return target as Color;
         },
         lineWidthMinPixels: 0,
+        updateTriggers: {
+          getFillColor: access
+        }
       }),
     ];
   }, [data, getColor, access]);

--- a/src/hooks/useColorScale.ts
+++ b/src/hooks/useColorScale.ts
@@ -2,11 +2,11 @@ import * as d3 from "d3";
 import { useCallback, useMemo } from "react";
 import { Table } from "apache-arrow";
 
-function useColorScale(data: Table | undefined, access: string) {
+function useColorScale(data: Table | undefined, access: string, access_class: string) {
   const { min, max } = useMemo(() => {
     if (!data) return { min: 0, max: 1 };
-    
-    const values = data.getChild(access)?.toArray();
+    const columnName = [access, access_class].join("_");
+    const values = data.getChild(columnName)?.toArray();
     const extent = d3.extent(values as number[]);
     return {
       min: extent[0] ?? 0,


### PR DESCRIPTION
Change the format of the table to be more flat, combining each combination of `access_category` and `access_type`. We'll now have 24 combinations (6 categories × 4 access types). Now we can load all access types at once without having to do another query every time the `access_type` state changes.

![image](https://github.com/user-attachments/assets/2438a5d4-e03e-45d1-8529-fde6779b5601)


